### PR TITLE
Fix: Add missing @tailwindcss/forms dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",
         "@popperjs/core": "^2.11.8",
+        "@tailwindcss/forms": "^0.5.10",
         "aos": "^2.3.4",
         "bcryptjs": "^2.4.3",
         "bootstrap": "^5.3.6",
@@ -1227,6 +1228,17 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/forms": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.10.tgz",
+      "integrity": "sha512-utI1ONF6uf/pPNO68kmN1b8rEwNXv3czukalo8VtJH8ksIkZXr3Q3VYudZLkCsDd4Wku120uF02hYK25XGPorw==",
+      "dependencies": {
+        "mini-svg-data-uri": "^1.2.3"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
       }
     },
     "node_modules/@tanstack/react-virtual": {
@@ -4373,6 +4385,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "bin": {
+        "mini-svg-data-uri": "cli.js"
       }
     },
     "node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@headlessui/react": "^2.2.4",
     "@heroicons/react": "^2.2.0",
     "@popperjs/core": "^2.11.8",
+    "@tailwindcss/forms": "^0.5.10",
     "aos": "^2.3.4",
     "bcryptjs": "^2.4.3",
     "bootstrap": "^5.3.6",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,13 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./src/**/*.{html,js}",
+    "./*.{html,js}"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [
+    require('@tailwindcss/forms'),
+  ],
+}


### PR DESCRIPTION
The project was failing to build due to the missing `@tailwindcss/forms` module. I've added the module as a dependency to `package.json` and ensured it is configured in `tailwind.config.js`.

This should resolve the CSS compilation errors related to the missing module.