### PR TITLE
Fix: Add missing @tailwindcss/aspect-ratio dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",
         "@popperjs/core": "^2.11.8",
+        "@tailwindcss/aspect-ratio": "^0.4.2",
         "@tailwindcss/forms": "^0.5.10",
         "aos": "^2.3.4",
         "bcryptjs": "^2.4.3",
@@ -1228,6 +1229,14 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/aspect-ratio": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/aspect-ratio/-/aspect-ratio-0.4.2.tgz",
+      "integrity": "sha512-8QPrypskfBa7QIMuKHg2TA7BqES6vhBrDLOv8Unb6FcFyd3TjKbc6lcmb9UPQHxfl24sXoJ41ux/H7qQQvfaSQ==",
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
     "node_modules/@tailwindcss/forms": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@headlessui/react": "^2.2.4",
     "@heroicons/react": "^2.2.0",
     "@popperjs/core": "^2.11.8",
+    "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/forms": "^0.5.10",
     "aos": "^2.3.4",
     "bcryptjs": "^2.4.3",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,5 +9,6 @@ module.exports = {
   },
   plugins: [
     require('@tailwindcss/forms'),
+    require('@tailwindcss/aspect-ratio'),
   ],
 }


### PR DESCRIPTION
The project was failing to build due to the missing `@tailwindcss/aspect-ratio` module, which is a required plugin for Tailwind CSS. This commit adds the module as a dependency to `package.json` and includes it in the `tailwind.config.js` plugins array.

This should resolve the CSS compilation errors related to the missing `@tailwindcss/aspect-ratio` module.