### PR TITLE
Fix: Improve error message display for reservation cancellation

### DIFF
--- a/gestion-hoteliere-main (1)/gestion-hoteliere-main/my-frontend/src/services/reservationService.js
+++ b/gestion-hoteliere-main (1)/gestion-hoteliere-main/my-frontend/src/services/reservationService.js
@@ -18,13 +18,18 @@ const API_BASE_URL = '/api'; // Assuming Express serves API routes under /api
 const handleResponse = async (response) => {
   if (!response.ok) {
     let errorData;
+    let errorMessage;
     try {
       errorData = await response.json();
+      // Use server's error message if available, otherwise use a generic one.
+      // The backend sends { "error": "message" } for some errors.
+      errorMessage = errorData.message || errorData.error || `HTTP error! status: ${response.status}`;
     } catch (e) {
-      // If response is not JSON, use status text
-      errorData = { message: response.statusText };
+      // If response is not JSON or parsing fails, use status text
+      errorMessage = `HTTP error! status: ${response.status}, ${response.statusText}`;
+      errorData = { message: response.statusText }; // Keep basic error data
     }
-    const error = new Error(errorData.message || `HTTP error! status: ${response.status}`);
+    const error = new Error(errorMessage);
     error.data = errorData; // Attach full error data if available
     error.status = response.status;
     throw error;


### PR DESCRIPTION
The frontend was displaying a generic "HTTP error! status: 400" when a reservation cancellation failed due to specific backend validation (e.g., cancellation not allowed, or too late).

This commit enhances the error handling in `my-frontend/src/services/reservationService.js` to extract and use the specific error message provided in the JSON response from the backend.

- I modified `handleResponse` in `reservationService.js` to prioritize `errorData.message` or `errorData.error` from the server's JSON response.
- I verified that `ReservationsPage.js` correctly displays the error message passed from the service.
- I added unit tests for `cancelReservation` in `reservationService.test.js` to cover:
    - Scenario where the backend returns a 400 error with a JSON message (e.g., {"error": "Annulation non autorisée"}).
    - Scenario where a 400 error response is not valid JSON.
    - Successful cancellation path.

This change will provide you with clearer feedback on why a reservation cancellation might have failed.