### PR TITLE
Feat: Update reservation cancellation policy to 5 days

### DIFF
--- a/gestion-hoteliere-main (1)/gestion-hoteliere-main/routes/reservations.js
+++ b/gestion-hoteliere-main (1)/gestion-hoteliere-main/routes/reservations.js
@@ -227,7 +227,7 @@ router.patch('/:id/cancel', authenticateToken, async (req, res) => {
       return res.status(400).json({ error: 'Annulation non autorisée' });
     }
 
-    if (moment().isAfter(moment(reservation.check_in_date).subtract(2, 'days'))) {
+    if (moment().isAfter(moment(reservation.check_in_date).subtract(5, 'days'))) {
       return res.status(400).json({ error: 'Annulation trop tardive' });
     }
 


### PR DESCRIPTION
I changed the reservation cancellation policy to allow you to cancel your reservations up to 5 days before the scheduled check-in date. Previously, the policy was 2 days.

- I modified the condition in the PATCH '/:id/cancel' route within `routes/reservations.js` to reflect the new 5-day window. The check `moment().isAfter(moment(reservation.check_in_date).subtract(2, 'days'))` was updated to `moment().isAfter(moment(reservation.check_in_date).subtract(5, 'days'))`.

This change provides you with more flexibility in managing your reservations.